### PR TITLE
Update to crawshaw.io/sqlite v0.2.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/daaku/sq3schema
 go 1.12
 
 require (
-	crawshaw.io/sqlite v0.1.3-0.20190520153332-66f853b01dfb
+	crawshaw.io/sqlite v0.2.5
 	github.com/daaku/ensure v0.0.0-20180215095550-9bd7e49e586d
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 // indirect
-	golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ crawshaw.io/iox v0.0.0-20181124134642-c51c3df30797 h1:yDf7ARQc637HoxDho7xjqdvO5Z
 crawshaw.io/iox v0.0.0-20181124134642-c51c3df30797/go.mod h1:sXBiorCo8c46JlQV3oXPKINnZ8mcqnye1EkVkqsectk=
 crawshaw.io/sqlite v0.1.3-0.20190520153332-66f853b01dfb h1:jKjr7R+PV9y9zuht2we+zbgGtsk8XiL1c8BhupMaYRQ=
 crawshaw.io/sqlite v0.1.3-0.20190520153332-66f853b01dfb/go.mod h1:igAO5JulrQ1DbdZdtVq48mnZUBAPOeFzer7VhDWNtW4=
+crawshaw.io/sqlite v0.2.5 h1:lUjWtEQJZApoL4V83cHsNeaGZkY5Ofmh8cGGBdZNxPU=
+crawshaw.io/sqlite v0.2.5/go.mod h1:igAO5JulrQ1DbdZdtVq48mnZUBAPOeFzer7VhDWNtW4=
 github.com/daaku/ensure v0.0.0-20180215095550-9bd7e49e586d h1:6qQEVZmQY0tAwVCUjARt0DNQ84fvulgHH0daELGR9bs=
 github.com/daaku/ensure v0.0.0-20180215095550-9bd7e49e586d/go.mod h1:Ow4+0ZvWSGA0FkpjHd3H5R0LiKuSXFBf7oBPzJpCmSk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -10,3 +12,5 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 h1:E2s37DuLxFhQD
 github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
This not only brings us up to date, but fixes an issue introduced by Go 1.13 with regards to API changes within the `xerrors` package.

(Not sure if this repo is being maintained anymore, but I love its simplicity and am using it in a couple of small personal projects!)